### PR TITLE
Fix. Missing string interpolation in query criteria

### DIFF
--- a/packages/openchs-android/src/service/IndividualService.js
+++ b/packages/openchs-android/src/service/IndividualService.js
@@ -194,7 +194,7 @@ class IndividualService extends BaseService {
                     dateMidnight,
                     dateMorning);
             if (!_.isEmpty(programEncounterCriteria))
-                programEncounters = programEncounters.filtered(programEncounterCriteria);
+                programEncounters = programEncounters.filtered(`${programEncounterCriteria}`);
             if (!_.isNil(addressFilter))
                 programEncounters = RealmQueryService.filterBasedOnAddress(ProgramEncounter.schema.name, programEncounters, addressFilter);
 
@@ -233,7 +233,7 @@ class IndividualService extends BaseService {
                     dateMidnight,
                     dateMorning);
             if (!_.isEmpty(encounterCriteria))
-                encounters = encounters.filtered(encounterCriteria);
+                encounters = encounters.filtered(`${encounterCriteria}`);
             if (!_.isNil(addressFilter))
                 encounters = RealmQueryService.filterBasedOnAddress(Encounter.schema.name, encounters, addressFilter);
 


### PR DESCRIPTION
This PR adds a fix for a missing string interpolation in IndividualService.js. Due to this the app fails to load and throws `Exception in HostFunction: predicate must be of type 'string', got (programEnrolment.individual.subjectType.uuid = "c49fafe9-f0c9-4268-9ed7-f96596245488")`.

This seems to be accidently missed by refactoring with this [commit](https://github.com/avniproject/avni-client/commit/0fd8ab673693788e1437b5a2930b3abd24e32362#diff-4f208e3e8f3342e3903698950f48ddc1dee83847b4bf9c0588eae07a1820160b).