### PR TITLE
Added a default IP for building the client- app to run on  Android Emulators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,13 @@ ignore_deps_changes:
 
 #for emulators using virtualbox
 ip:=$(shell ifconfig | grep -A 2 'vboxnet' | grep 'inet ' | tail -1 | xargs | cut -d ' ' -f 2 | cut -d ':' -f 2)
-#for default Andoird Emulator
+
+# for default Andoird Emulator
 ip:=$(if $(ip),$(ip),$(shell ifconfig | grep -A 2 'wlp' | grep 'inet ' | tail -1 | xargs | cut -d ' ' -f 2 | cut -d ':' -f 2))
 ip:=$(if $(ip),$(ip),$(shell ifconfig | grep -A 2 'en0' | grep 'inet ' | tail -1 | xargs | cut -d ' ' -f 2 | cut -d ':' -f 2))
 ip:=$(if $(ip),$(ip),$(shell ifconfig | grep -A 4 'en0' | grep 'inet ' | tail -1 | xargs | cut -d ' ' -f 2 | cut -d ':' -f 2))
+ip:=$(if $(ip),$(ip),10.0.3.2)
+
 AVNI_HOST?=$(ip)
 sha:=$(shell git rev-parse --short=4 HEAD)
 


### PR DESCRIPTION
The client app was not able to connect with the local avni-server, this was due to a shell command executed while doing "make run_app" which was not returning any IP due to a different bash configuration. 
This was fixed by using default IP gateway of  emulators.