### PR TITLE
Fix group name overlapping Edit button in observation table

### DIFF
--- a/packages/openchs-android/src/views/common/Observations.js
+++ b/packages/openchs-android/src/views/common/Observations.js
@@ -249,7 +249,7 @@ class Observations extends AbstractComponent {
     }
 
     observationTable(groupUUID, groupName, observations, groupStyles, quickFormEdit) {
-        const initialFlex = quickFormEdit ? 1 : 0.9;
+        const initialFlex = quickFormEdit ? 0.85 : 0.9;
         return <View style={{flexDirection: 'column'}} key={groupUUID}>
             <View style={[{
                 flexDirection: 'row',
@@ -258,11 +258,11 @@ class Observations extends AbstractComponent {
                 padding: 4,
                 backgroundColor: 'rgba(0, 0, 0, 0.12)'
             }, this.styles.observationRow, this.styles.observationColumn, groupStyles]}>
-                <View style={{flex: initialFlex, flexWrap: 'wrap'}}>
-                    <Text style={[{fontWeight: 'bold'}, groupStyles]}>{this.I18n.t(groupName)}</Text>
+                <View style={{flex: initialFlex}}>
+                    <Text style={[{fontWeight: 'bold'}, groupStyles]} numberOfLines={2} ellipsizeMode="tail">{this.I18n.t(groupName)}</Text>
                 </View>
                 {groupUUID && quickFormEdit &&
-                <View style={{flex: 0.1, minWidth: 5}}>
+                <View style={{flex: 0.15, minWidth: 5}}>
                     <TouchableOpacity
                         onPress={() => this.onFEGEdit(groupUUID)}>
                         <Text style={{color: Colors.ActionButtonColor,}}>{this.I18n.t('edit')}</Text>


### PR DESCRIPTION
## Summary
- Long form element group names in the registration details section were wrapping and overlapping the Edit button
- Added `numberOfLines={2}` and `ellipsizeMode="tail"` to truncate long group names with ellipsis
- Adjusted flex values: name View `0.85`, Edit button View `0.15` (was `1` and `0.1` respectively)
- Removed `flexWrap: 'wrap'` from the name View

## Test plan
- [ ] Open a subject with a long form element group name in the registration details section
- [ ] Verify the group name is truncated with `...` and does not overlap the Edit button
- [ ] Verify the Edit button is fully visible and tappable
- [ ] Verify short group names still display fully without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined quick-form group header layout to improve text display and spacing during editing mode. Group names now truncate gracefully with a two-line limit and ellipsis, while header and button proportions have been adjusted for better visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->