### PR TITLE
build: add run_app_prerelease_tanuh[_dev] make targets

### DIFF
--- a/makefiles/tanuh.mk
+++ b/makefiles/tanuh.mk
@@ -237,4 +237,15 @@ run_app_tanuh_dev: ## Install + launch tanuh debug build, prod backend with dev 
 run-app-tanuh: run_app_tanuh
 run-app-tanuh-dev: run_app_tanuh_dev
 
-.PHONY: tanuh-setup tanuh-encrypt tanuh-apk _tanuh-release-assemble tanuh-ensemble tanuh-ensemble-apk tanuh-aab tanuh-universal-apk tanuh-ensemble-aab tanuh-ensemble-universal-apk tanuh-clean tanuh-placeholder run_app_tanuh run_app_tanuh_dev run-app-tanuh run-app-tanuh-dev
+run_app_prerelease_tanuh: ## Install + launch tanuh debug build, prerelease backend.
+	$(MAKE) as_prerelease flavor=tanuh
+	$(MAKE) _run_app flavor=tanuh
+
+run_app_prerelease_tanuh_dev: ## Install + launch tanuh debug build, prerelease backend with dev menu.
+	$(MAKE) as_prerelease_dev flavor=tanuh
+	$(MAKE) _run_app flavor=tanuh
+
+run-app-prerelease-tanuh: run_app_prerelease_tanuh
+run-app-prerelease-tanuh-dev: run_app_prerelease_tanuh_dev
+
+.PHONY: tanuh-setup tanuh-encrypt tanuh-apk _tanuh-release-assemble tanuh-ensemble tanuh-ensemble-apk tanuh-aab tanuh-universal-apk tanuh-ensemble-aab tanuh-ensemble-universal-apk tanuh-clean tanuh-placeholder run_app_tanuh run_app_tanuh_dev run-app-tanuh run-app-tanuh-dev run_app_prerelease_tanuh run_app_prerelease_tanuh_dev run-app-prerelease-tanuh run-app-prerelease-tanuh-dev


### PR DESCRIPTION
Adds two GNU Make targets (plus hyphenated aliases) that install + launch the tanuh debug build against the **prerelease** backend, so QA can run the tanuh flavour against https://prerelease.avniproject.org.

## What
- `run_app_prerelease_tanuh` / `run-app-prerelease-tanuh`
- `run_app_prerelease_tanuh_dev` / `run-app-prerelease-tanuh-dev`

They mirror the existing `run_app_tanuh` / `run_app_tanuh_dev` targets in `makefiles/tanuh.mk`, swapping `as_prod` / `as_prod_dev` for the already-defined `as_prerelease` / `as_prerelease_dev` config generators. `_run_app flavor=tanuh` is unchanged.

## Why
Enables QA of the tanuh build against the prerelease backend (stest on prerelease.avniproject.org) without a signed release build.

## Verification
`make -n run_app_prerelease_tanuh_dev` expands to `make as_prerelease_dev flavor=tanuh` (writes prerelease_dev Config.js) then `make _run_app flavor=tanuh` (metro_config + `react-native run-android --mode tanuhDebug`).

Touches only `makefiles/tanuh.mk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Make targets for running the app in a prerelease TANUH flow, including standard and dev variants.
  * Added matching hyphenated aliases for easier command-line use.
  * Updated command recognition so the new prerelease targets are available in common build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->