### PR TITLE
Query-census harness: classify .filtered() corpora through RealmQueryParser (#1978 done-check)

### DIFF
--- a/packages/openchs-android/scripts/query-census/.gitignore
+++ b/packages/openchs-android/scripts/query-census/.gitignore
@@ -1,0 +1,3 @@
+corpus.jsonl
+census-results.jsonl
+prop-schema-map.json

--- a/packages/openchs-android/scripts/query-census/QueryCensus.js
+++ b/packages/openchs-android/scripts/query-census/QueryCensus.js
@@ -1,0 +1,85 @@
+/**
+ * Query census — classify a corpus of .filtered() predicates through RealmQueryParser.
+ *
+ * Buckets:
+ *   FULL_SQL      - fully translated (incl. opportunistic SUBQUERY->IN/json_each)
+ *   PARTIAL       - SQL pre-narrow + JS residual (partialParse + skippedClauses)
+ *   FULL_FALLBACK - unsupported: whole-table hydration + JS post-filter (the perf cliff)
+ *   PARSE_ERROR   - parser threw; also lands in JS fallback (worst case)
+ *   DYNAMIC       - predicate is a runtime variable; not statically classifiable
+ *   HARNESS_ERROR - harness-level exception (investigate)
+ *
+ * Corpus entries (JSONL): {schema, arg, n, dynamic, ...} — see README.md for how
+ * to produce a corpus from prod rules (avni-product-ops) or from this codebase
+ * (extract_client_corpus.py).
+ */
+import {EntityMappingConfig} from "openchs-models";
+import RealmQueryParser from "../../src/framework/db/RealmQueryParser";
+
+const DUMMY_ARGS = Array.from({length: 16}, () => "PH");
+
+function buildSchemaMap() {
+    const schemas = EntityMappingConfig.getInstance().getRealmConfig().schema;
+    const schemaMap = new Map();
+    for (const s of schemas) {
+        const raw = s && s.properties ? s : (s && s.schema ? s.schema : s);
+        if (raw && raw.name) schemaMap.set(raw.name, raw);
+    }
+    return schemaMap;
+}
+
+function classifyEntry(e, schemaMap) {
+    if (e.dynamic) return {bucket: "DYNAMIC", reason: null, skipped: null};
+    try {
+        const r = RealmQueryParser.parse(e.arg, DUMMY_ARGS, e.schema, schemaMap);
+        if (r.unsupported) {
+            const bucket = (r.reason || "").startsWith("Parse error") ? "PARSE_ERROR" : "FULL_FALLBACK";
+            return {bucket, reason: r.reason || null, skipped: null};
+        }
+        if (r.partialParse && r.skippedClauses && r.skippedClauses.length > 0) {
+            return {bucket: "PARTIAL", reason: null, skipped: r.skippedClauses};
+        }
+        return {bucket: "FULL_SQL", reason: null, skipped: null};
+    } catch (err) {
+        return {bucket: "HARNESS_ERROR", reason: String((err && err.message) || err), skipped: null};
+    }
+}
+
+function runCensus(entries) {
+    const schemaMap = buildSchemaMap();
+    const origWarn = console.warn;
+    console.warn = () => {}; // parser warns on every partial parse
+    const buckets = {};
+    const results = entries.map((e) => {
+        const {bucket, reason, skipped} = classifyEntry(e, schemaMap);
+        buckets[bucket] = buckets[bucket] || {distinct: 0, weighted: 0};
+        buckets[bucket].distinct += 1;
+        buckets[bucket].weighted += e.n || 1;
+        return {...e, bucket, reason, skipped};
+    });
+    console.warn = origWarn;
+    const total = {
+        distinct: entries.length,
+        weighted: entries.reduce((a, e) => a + (e.n || 1), 0),
+    };
+    return {results, buckets, total};
+}
+
+const BUCKET_ORDER = ["FULL_SQL", "PARTIAL", "FULL_FALLBACK", "PARSE_ERROR", "DYNAMIC", "HARNESS_ERROR"];
+
+function formatBucketTable({buckets, total}) {
+    const lines = [
+        `predicates: ${total.distinct} distinct, ${total.weighted} weighted (by occurrences)`,
+    ];
+    for (const b of BUCKET_ORDER) {
+        if (!buckets[b]) continue;
+        const {distinct, weighted} = buckets[b];
+        lines.push(
+            `${b.padEnd(14)} distinct=${String(distinct).padStart(6)} (${((100 * distinct) / total.distinct).toFixed(1)}%)   ` +
+            `weighted=${String(weighted).padStart(7)} (${((100 * weighted) / total.weighted).toFixed(1)}%)`
+        );
+    }
+    return lines.join("\n");
+}
+
+export {buildSchemaMap, classifyEntry, runCensus, formatBucketTable, DUMMY_ARGS, BUCKET_ORDER};

--- a/packages/openchs-android/scripts/query-census/README.md
+++ b/packages/openchs-android/scripts/query-census/README.md
@@ -1,0 +1,49 @@
+# Query census — measure the Realm→SQLite fallback surface
+
+Classifies a corpus of `.filtered()` predicates through the **checked-out**
+`RealmQueryParser` into buckets:
+
+| Bucket | Meaning |
+|---|---|
+| FULL_SQL | fully translated (incl. opportunistic SUBQUERY→`IN`/`json_each`) |
+| PARTIAL | SQL pre-narrow + JS residual (`partialParse` + `skippedClauses`) |
+| FULL_FALLBACK | whole-table hydration + JS post-filter — **the perf cliff** |
+| PARSE_ERROR | parser threw; lands in JS fallback with the raw query |
+| DYNAMIC | predicate is a runtime variable — not statically classifiable |
+
+Background, prod-wide results, and the fix plan: the parser-fix census in
+[avni-product-ops](https://github.com/avniproject/avni-product-ops/blob/main/analysis/realm-sqlite-perf-risks/parser-fix-census.md).
+Related stories: [#1977](https://github.com/avniproject/avni-client/issues/1977),
+[#1978](https://github.com/avniproject/avni-client/issues/1978),
+[#1981](https://github.com/avniproject/avni-client/issues/1981).
+
+## Corpus A — this codebase (self-contained)
+
+```bash
+cd packages/openchs-android
+node scripts/query-census/dump-prop-schema-map.mjs      # once per openchs-models bump
+python3 scripts/query-census/extract_client_corpus.py   # -> scripts/query-census/corpus.jsonl
+CENSUS_CORPUS=scripts/query-census/corpus.jsonl npx jest QueryCensus
+```
+
+## Corpus B — real org rules from prod
+
+Produced by `analysis/realm-sqlite-perf-risks/scripts/census/extract_corpus.py` in
+avni-product-ops (needs read-only prod-DB access; ops concern). Point `CENSUS_CORPUS`
+at the resulting `corpus.jsonl` and run the same jest command.
+
+**Corpus files contain org rule text — never commit them** (this dir's `.gitignore`
+covers the default filenames).
+
+## The #1978 done-check
+
+```bash
+CENSUS_CORPUS=<prod-corpus.jsonl> CENSUS_MAX_FALLBACK_WEIGHTED=50 npx jest QueryCensus
+```
+
+Fails if the weighted FULL_FALLBACK count is not below the budget. Without the env
+vars the test is skipped, so normal `npx jest` runs and CI are unaffected.
+
+`census-results.jsonl` (written next to the corpus) has one line per distinct
+predicate with its bucket, parser reason, and skipped clauses — grep it for
+`FULL_FALLBACK` to see exactly which shapes still hydrate whole tables.

--- a/packages/openchs-android/scripts/query-census/dump-prop-schema-map.mjs
+++ b/packages/openchs-android/scripts/query-census/dump-prop-schema-map.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Generates prop-schema-map.json: list/linkingObjects property name -> element schema
+// name(s), from the openchs-models version pinned by this checkout. Used by
+// extract_client_corpus.py to infer the root schema of chained receivers like
+// `individual.encounters.filtered(...)`.
+//
+//   node scripts/query-census/dump-prop-schema-map.mjs
+import fs from "node:fs";
+import path from "node:path";
+import {createRequire} from "node:module";
+import {fileURLToPath} from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(path.join(here, "..", "..", "package.json"));
+const {EntityMappingConfig} = require("openchs-models");
+
+const schemas = EntityMappingConfig.getInstance().getRealmConfig().schema;
+const propMap = {};
+for (const s of schemas) {
+    const raw = s && s.properties ? s : (s && s.schema ? s.schema : s);
+    if (!raw || !raw.properties) continue;
+    for (const [prop, def] of Object.entries(raw.properties)) {
+        let target = null;
+        if (typeof def === "object" && (def.type === "list" || def.type === "linkingObjects") && def.objectType) {
+            target = def.objectType;
+        } else if (typeof def === "string" && def.endsWith("[]")) {
+            target = def.slice(0, -2);
+        }
+        if (target) {
+            propMap[prop] = propMap[prop] || {};
+            propMap[prop][target] = (propMap[prop][target] || 0) + 1;
+        }
+    }
+}
+
+const out = path.join(here, "prop-schema-map.json");
+fs.writeFileSync(out, JSON.stringify(propMap, null, 1));
+console.log(`${Object.keys(propMap).length} properties -> ${out}`);

--- a/packages/openchs-android/scripts/query-census/extract_client_corpus.py
+++ b/packages/openchs-android/scripts/query-census/extract_client_corpus.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Extract every .filtered() predicate from this codebase (service/DAO/view layer)
+into corpus.jsonl for the query census (see README.md). Self-contained — stdlib only.
+
+Usage (from packages/openchs-android):
+  node scripts/query-census/dump-prop-schema-map.mjs          # once per models bump
+  python3 scripts/query-census/extract_client_corpus.py       # -> corpus.jsonl here
+  CENSUS_CORPUS=scripts/query-census/corpus.jsonl npx jest QueryCensus
+
+Root-schema inference, in priority order:
+  1. property receiver (`individual.encounters.filtered(...)`) via prop-schema-map.json;
+     `encounters` is disambiguated by the owner token (enrolment -> ProgramEncounter).
+  2. nearest `X.schema.name` or `.objects('X')` anchor within a 600-char window back
+     (covers `this.getAll(EntityQueue.schema.name).filtered(...)` and chained calls).
+  3. otherwise null (census still parses; structure-level classification only).
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+FILTERED_ARG_RE = re.compile(r"\.filtered\s*\(\s*(['\"`])(.*?)\1", re.DOTALL)
+FILTERED_POS_RE = re.compile(r"\.filtered\s*\(")
+OBJECTS_SCHEMA_RE = re.compile(r"\.objects\s*\(\s*(['\"`])(\w+)\1\s*\)")
+SCHEMA_NAME_RE = re.compile(r"([A-Za-z_$][\w$]*)\.schema\.name")
+RECEIVER_RE = re.compile(r"([\w$]+(?:\.[\w$]+)*)$")
+# one nesting level of braces inside ${...}
+INTERP = r"\$\{(?:[^{}]|\{[^{}]*\})*\}"
+QUOTED_INTERP_RE = re.compile(r"(['\"])" + INTERP + r"\1")
+BARE_INTERP_RE = re.compile(INTERP)
+WHOLE_ARG_DYNAMIC_RE = re.compile(r"^\s*" + INTERP + r"\s*$")
+
+EXCLUDE_PARTS = ("framework/db",)  # the sqlite shim itself, incl. the parser
+WINDOW = 600
+
+AMBIGUOUS_HINTS = {
+    # prop -> [(owner-token-substring, schema)], first hit wins; "" = default
+    "encounters": [("enrol", "ProgramEncounter"), ("", "Encounter")],
+    "items": [("detail", "ChecklistItemDetail"), ("", "ChecklistItem")],
+}
+
+
+def strip_js_comments(text):
+    """Blank out // line and /* */ block comments, string-aware ('http://…'
+    inside a string survives). Offset-preserving: every stripped char becomes
+    a space (newlines kept), so match positions map back to the original."""
+    out = list(text)
+    i, n = 0, len(text)
+    in_str = None  # one of ' " `
+    while i < n:
+        c = text[i]
+        if in_str:
+            if c == "\\":
+                i += 2
+                continue
+            if c == in_str:
+                in_str = None
+            i += 1
+            continue
+        if c in "'\"`":
+            in_str = c
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                out[i] = " "
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            out[i] = out[i + 1] = " "
+            i += 2
+            while i < n and not (text[i] == "*" and i + 1 < n and text[i + 1] == "/"):
+                if text[i] != "\n":
+                    out[i] = " "
+                i += 1
+            if i < n:
+                out[i] = out[i + 1] = " "
+                i += 2
+            continue
+        i += 1
+    return "".join(out)
+
+
+def normalize_interp(arg):
+    """Make template-literal predicates parseable: '${x}' -> 'PH', bare ${x} -> 'PH',
+    and `in 'PH'` -> `in {'PH'}` (interpolated IN-lists)."""
+    a = QUOTED_INTERP_RE.sub("'PH'", arg)
+    a = BARE_INTERP_RE.sub("'PH'", a)
+    a = re.sub(r"\b(in)\s+'PH'", r"\1 {'PH'}", a, flags=re.IGNORECASE)
+    return a
+
+
+def load_prop_map(outdir):
+    p = outdir / "prop-schema-map.json"
+    if not p.exists():
+        sys.exit(f"missing {p} — run: node scripts/query-census/dump-prop-schema-map.mjs")
+    return {k: sorted(v) for k, v in json.loads(p.read_text()).items()
+            if v and "string" not in v}
+
+
+def infer_schema(code, pos, prop_map):
+    before = code[:pos]
+    m = RECEIVER_RE.search(before)
+    if m:  # e.g. individual.encounters | encounters
+        segs = m.group(1).split(".")
+        prop = segs[-1]
+        if prop in prop_map:
+            targets = prop_map[prop]
+            if len(targets) == 1:
+                return targets[0], "prop"
+            owner = segs[-2].lower() if len(segs) > 1 else ""
+            for hint, schema in AMBIGUOUS_HINTS.get(prop, []):
+                if hint in owner:
+                    return schema, "prop~"
+    window = code[max(0, pos - WINDOW):pos]
+    anchors = [(a.start(), a.group(2)) for a in OBJECTS_SCHEMA_RE.finditer(window)]
+    anchors += [(a.start(), a.group(1)) for a in SCHEMA_NAME_RE.finditer(window)]
+    if anchors:
+        return max(anchors)[1], "window"
+    return None, "unknown"
+
+
+def main():
+    here = Path(__file__).resolve().parent
+    src = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else here.parents[1] / "src"
+    outdir = Path(sys.argv[2]).resolve() if len(sys.argv) > 2 else here
+    prop_map = load_prop_map(outdir)
+    corpus = {}
+    sites = 0
+    for f in sorted(src.rglob("*.js")):
+        rel = str(f.relative_to(src))
+        if any(x in rel for x in EXCLUDE_PARTS):
+            continue
+        code = strip_js_comments(f.read_text(encoding="utf-8", errors="replace"))
+        quoted_at = {m.start(): m for m in FILTERED_ARG_RE.finditer(code)}
+        for pm in FILTERED_POS_RE.finditer(code):
+            sites += 1
+            line = code.count("\n", 0, pm.start()) + 1
+            schema, anchor = infer_schema(code, pm.start(), prop_map)
+            qm = quoted_at.get(pm.start())
+            if qm:
+                raw = qm.group(2).strip()
+                interp = "${" in raw
+                dynamic = bool(WHOLE_ARG_DYNAMIC_RE.match(raw))
+                arg = raw if dynamic else (normalize_interp(raw) if interp else raw)
+            else:  # variable / expression argument — not statically classifiable
+                tail = code[pm.end():pm.end() + 60].split(")")[0]
+                arg, interp, dynamic = f"${{{tail.strip()}}}", True, True
+            e = corpus.setdefault((schema, arg), {
+                "schema": schema, "arg": arg, "interp": interp, "dynamic": dynamic,
+                "n": 0, "anchor": anchor, "sites": [],
+            })
+            e["n"] += 1
+            if len(e["sites"]) < 5:
+                e["sites"].append(f"{rel}:{line}")
+    out = outdir / "corpus.jsonl"
+    with out.open("w") as fh:
+        for e in corpus.values():
+            fh.write(json.dumps(e) + "\n")
+    unknown = sum(e["n"] for e in corpus.values() if e["anchor"] == "unknown")
+    print(f".filtered() sites   : {sites}", file=sys.stderr)
+    print(f"distinct predicates : {len(corpus)} -> {out}", file=sys.stderr)
+    print(f"  unknown root (weighted): {unknown}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/openchs-android/test/framework/db/QueryCensusTest.js
+++ b/packages/openchs-android/test/framework/db/QueryCensusTest.js
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+import {runCensus, formatBucketTable} from "../../../scripts/query-census/QueryCensus";
+
+/**
+ * Env-gated census run — skipped in normal test runs / CI.
+ *
+ *   CENSUS_CORPUS=/path/to/corpus.jsonl npx jest QueryCensus
+ *
+ * Writes census-results.jsonl next to the corpus and prints the bucket table.
+ * Optionally assert the perf-cliff budget (the avni-client#1978 done-check):
+ *
+ *   CENSUS_CORPUS=… CENSUS_MAX_FALLBACK_WEIGHTED=50 npx jest QueryCensus
+ */
+const corpusPath = process.env.CENSUS_CORPUS;
+const describeIf = corpusPath ? describe : describe.skip;
+
+describeIf("Query census over a predicate corpus", () => {
+    it("classifies every corpus predicate through RealmQueryParser", () => {
+        const entries = fs.readFileSync(corpusPath, "utf8")
+            .split("\n").filter(Boolean).map(JSON.parse);
+        const {results, buckets, total} = runCensus(entries);
+
+        const outPath = path.join(path.dirname(corpusPath), "census-results.jsonl");
+        fs.writeFileSync(outPath, results.map((r) => JSON.stringify(r)).join("\n") + "\n");
+        // eslint-disable-next-line no-console
+        console.log(`\n=== Query census ===\n${formatBucketTable({buckets, total})}\nresults -> ${outPath}\n`);
+
+        expect(buckets.HARNESS_ERROR).toBeUndefined();
+
+        if (process.env.CENSUS_MAX_FALLBACK_WEIGHTED !== undefined) {
+            const budget = Number(process.env.CENSUS_MAX_FALLBACK_WEIGHTED);
+            const fallbackWeighted = (buckets.FULL_FALLBACK && buckets.FULL_FALLBACK.weighted) || 0;
+            expect(fallbackWeighted).toBeLessThan(budget);
+        }
+    });
+});


### PR DESCRIPTION
## What

In-repo tooling to measure the Realm→SQLite fallback surface: classifies a corpus of `.filtered()` predicates through the **checked-out** `RealmQueryParser` into FULL_SQL / PARTIAL / FULL_FALLBACK / PARSE_ERROR / DYNAMIC buckets.

Moved from [avni-product-ops](https://github.com/avniproject/avni-product-ops/blob/main/analysis/realm-sqlite-perf-risks/parser-fix-census.md), where it needed a copy of the parser files — an indirection that already produced one false alarm from an openchs-models version skew. In-repo, it always tests the shipped parser.

## Why

This is the **done-check for #1978** (post-fix census: FULL_FALLBACK weighted < ~50, from 517) and the verification harness for #1977:

```bash
CENSUS_CORPUS=<prod-corpus.jsonl> CENSUS_MAX_FALLBACK_WEIGHTED=50 npx jest QueryCensus
```

## How

- `scripts/query-census/QueryCensus.js` — classifier; schemaMap built from the pinned openchs-models.
- `test/framework/db/QueryCensusTest.js` — env-gated jest runner: **skipped unless `CENSUS_CORPUS` is set** (plain `npx jest` / CI unaffected — verified). Writes `census-results.jsonl` next to the corpus and prints the bucket table.
- `scripts/query-census/extract_client_corpus.py` + `dump-prop-schema-map.mjs` — self-contained extraction of this codebase's own 240 call sites (corpus A); prod-rule corpora (corpus B) come from the ops repo's DB extractor.
- Corpus/result files are gitignored — they contain org rule text and must not land in this public repo.

## Verified

Reproduces the census run recorded in the ops doc exactly, via jest on this branch (240 sites → 198 distinct): FULL_SQL 138/165w · FULL_FALLBACK 14/17w · PARSE_ERROR 3/4w (all normalization artifacts) · DYNAMIC 43/54w. Suite passes in ~4s; without env vars the suite is skipped in 0.7s.

Refs #1978, #1977. Census + fix plan: [parser-fix-census.md](https://github.com/avniproject/avni-product-ops/blob/main/analysis/realm-sqlite-perf-risks/parser-fix-census.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)