### PR TITLE
Include the subject's name in shared PDF file names

### DIFF
--- a/packages/openchs-android/src/service/FormPDFService.js
+++ b/packages/openchs-android/src/service/FormPDFService.js
@@ -1,6 +1,5 @@
 import BaseService from "./BaseService";
 import Service from "../framework/bean/Service";
-import moment from "moment";
 import _ from "lodash";
 import {Observation} from "avni-models";
 import ConceptService from "./ConceptService";
@@ -9,7 +8,7 @@ import IndividualService from "./IndividualService";
 import EncounterService from "./EncounterService";
 import FormMappingService from "./FormMappingService";
 import MessageService from "./MessageService";
-import PDFGenerationService, {PAGE} from "./PDFGenerationService";
+import PDFGenerationService, {PAGE, buildPdfFileName} from "./PDFGenerationService";
 import General from "../utility/General";
 import ErrorUtil from "../framework/errorHandling/ErrorUtil";
 
@@ -21,11 +20,6 @@ function escapeHtml(value) {
         .replace(/>/g, "&gt;")
         .replace(/"/g, "&quot;")
         .replace(/'/g, "&#39;");
-}
-
-function snakeCase(str) {
-    const out = _.snakeCase(_.deburr(String(str || "")));
-    return _.isEmpty(out) ? "form" : out;
 }
 
 const CONTENT_AREA_HEIGHT_MM = PAGE.heightMm - PAGE.marginBottomMm;
@@ -229,13 +223,14 @@ class FormPDFService extends BaseService {
                     </html>`;
     }
 
-    _buildFileName(formTitle) {
-        return `${snakeCase(formTitle)}_${moment().format("DD_MM_YYYY")}`;
+    _buildFileName(individual, formTitle) {
+        const name = _.get(individual, "getTranslatedNameString") ? individual.getTranslatedNameString(this.I18n) : _.get(individual, "nameString");
+        return buildPdfFileName(name, formTitle);
     }
 
     _shareForm({individual, formTitle, formMeta, observations, form}) {
         const html = this._buildHtml({individual, formTitle, formMeta, observations, form});
-        const fileName = this._buildFileName(formTitle);
+        const fileName = this._buildFileName(individual, formTitle);
         return this.getService(PDFGenerationService).shareHtmlAsPdf(html, fileName);
     }
 

--- a/packages/openchs-android/src/service/FormShareService.js
+++ b/packages/openchs-android/src/service/FormShareService.js
@@ -14,14 +14,9 @@ import UserInfoService from "./UserInfoService";
 import RuleEvaluationService from "./RuleEvaluationService";
 import FormPDFService from "./FormPDFService";
 import FormShareTemplateService from "./FormShareTemplateService";
-import PDFGenerationService from "./PDFGenerationService";
+import PDFGenerationService, {buildPdfFileName} from "./PDFGenerationService";
 import General from "../utility/General";
 import ErrorUtil from "../framework/errorHandling/ErrorUtil";
-
-function snakeCase(str) {
-    const out = _.snakeCase(_.deburr(String(str || "")));
-    return _.isEmpty(out) ? "form" : out;
-}
 
 function renderMustache(template, data) {
     if (_.isEmpty(template)) return "";
@@ -110,7 +105,7 @@ class FormShareService extends BaseService {
     // ---------- PDF branch ----------
 
     async _sharePdf(ctx) {
-        const {form, ruleOut, formTitle} = ctx;
+        const {form, ruleOut, formTitle, individual} = ctx;
         const hasCustomPdf = _.isPlainObject(ruleOut?.data) && form && form.hasShareTemplate && form.hasShareTemplate();
         if (hasCustomPdf) {
             try {
@@ -118,8 +113,8 @@ class FormShareService extends BaseService {
                 if (!_.isEmpty(templateHtml)) {
                     // Consistent with custom cards: the template owns the full HTML output.
                     const html = renderMustache(templateHtml, ruleOut.data);
-                    const fileName = `${snakeCase(formTitle)}_${moment().format("DD_MM_YYYY")}`;
-                    return await this.getService(PDFGenerationService).shareHtmlAsPdf(html, fileName);
+                    const subjectName = _.get(individual, "getTranslatedNameString") ? individual.getTranslatedNameString(this.I18n) : _.get(individual, "nameString");
+                    return await this.getService(PDFGenerationService).shareHtmlAsPdf(html, buildPdfFileName(subjectName, formTitle));
                 }
                 General.logDebug("FormShareService", `Share template ${form.shareTemplateS3Key} fetched but empty; falling back to default PDF`);
             } catch (e) {

--- a/packages/openchs-android/src/service/PDFGenerationService.js
+++ b/packages/openchs-android/src/service/PDFGenerationService.js
@@ -32,6 +32,18 @@ function escapeHtml(value) {
         .replace(/'/g, "&#39;");
 }
 
+function fileNamePart(value) {
+    return _.snakeCase(_.deburr(String(value || "")));
+}
+
+// Subject name leads so that a day's shared PDFs stay distinguishable: without it
+// every share of the same form on the same day produces an identical name and the
+// receiving app disambiguates them as "(1)", "(2)".
+export function buildPdfFileName(subjectName, formTitle) {
+    const stem = [fileNamePart(subjectName), fileNamePart(formTitle)].filter(part => !_.isEmpty(part)).join("_");
+    return `${_.isEmpty(stem) ? "form" : stem}_${moment().format("DD_MM_YYYY")}`;
+}
+
 // Generic HTML → PDF → share-sheet pipeline. Knows nothing about Avni domain entities.
 // Domain-specific HTML composition (e.g. subject header, observation rows for forms;
 // custom card content for dashboards) lives in callers like FormPDFService.

--- a/packages/openchs-android/test/service/PdfFileNameTest.js
+++ b/packages/openchs-android/test/service/PdfFileNameTest.js
@@ -1,0 +1,45 @@
+// Shared PDFs used to be named form-and-date only, so every slip shared on one day
+// collided and the receiving app disambiguated them as "(1)", "(2)". The subject name
+// now leads. Native modules are mocked so the module loads without a TurboModule registry.
+
+import {assert} from "chai";
+import moment from "moment";
+
+jest.mock("../../src/framework/bean/Service", () => () => (target) => target);
+jest.mock("react-native-share", () => ({open: jest.fn(() => Promise.resolve())}));
+jest.mock("react-native-html-to-pdf", () => ({convert: jest.fn(() => Promise.resolve({filePath: "/tmp/x.pdf"}))}));
+jest.mock("react-native-fs", () => ({CachesDirectoryPath: "/tmp", exists: jest.fn(), unlink: jest.fn(), moveFile: jest.fn()}));
+
+import {buildPdfFileName} from "../../src/service/PDFGenerationService";
+
+describe("buildPdfFileName", () => {
+    const today = moment().format("DD_MM_YYYY");
+
+    it("leads with the subject name, then the form title and the date", () => {
+        assert.equal(buildPdfFileName("Ramesh Kumar", "Referral Slip"), `ramesh_kumar_referral_slip_${today}`);
+    });
+
+    it("gives two patients distinct names for the same form on the same day", () => {
+        assert.notEqual(
+            buildPdfFileName("Ramesh Kumar", "Referral Slip"),
+            buildPdfFileName("Sunita Devi", "Referral Slip")
+        );
+    });
+
+    it("falls back to the form title alone when the subject has no name", () => {
+        assert.equal(buildPdfFileName(null, "Referral Slip"), `referral_slip_${today}`);
+        assert.equal(buildPdfFileName("", "Referral Slip"), `referral_slip_${today}`);
+    });
+
+    it("falls back to 'form' when neither name is usable", () => {
+        assert.equal(buildPdfFileName(null, null), `form_${today}`);
+    });
+
+    it("strips accents and punctuation so the result is a usable file name", () => {
+        assert.equal(buildPdfFileName("José D'Souza", "Referral Slip"), `jose_d_souza_referral_slip_${today}`);
+    });
+
+    it("keeps non-Latin names intact rather than dropping them", () => {
+        assert.equal(buildPdfFileName("रमेश कुमार", "Referral Slip"), `रमेश_कुमार_referral_slip_${today}`);
+    });
+});


### PR DESCRIPTION
## Problem

Every PDF shared from a form is named `<form-title>_<date>`:

```js
const fileName = `${snakeCase(formTitle)}_${moment().format("DD_MM_YYYY")}`;
```

So every share of the same form on the same day produces an identical file name. The receiving app then disambiguates them as `(1)`, `(2)`, `(3)`. A field worker who has shared several documents in a day cannot tell which file belongs to which patient.

This surfaced on the Tanuh oral-cancer implementation, where workers share a prefilled Referral Slip per patient and were getting `referral_slip_30_07_2026.pdf` for every one of them. It is not Tanuh-specific: it affects every organisation and every shared form.

There is no configuration lever for this today. The share rule returns only `{data, text}`, so an implementation cannot influence the file name.

## Change

The subject's name now leads the file name:

```
ramesh_kumar_referral_slip_30_07_2026.pdf
```

- The builder moved into `PDFGenerationService` as `buildPdfFileName(subjectName, formTitle)`, next to the generation pipeline it feeds.
- Both call sites use it: `FormShareService` (custom share template) and `FormPDFService` (default layout), so the two paths cannot drift apart again.
- A duplicated `snakeCase` helper is gone from both callers, along with a `moment` import in `FormPDFService` that became unused.
- The subject name is read the same way the surrounding code already reads it: `getTranslatedNameString(I18n)` where available, otherwise `nameString`.

Behaviour is unchanged when a subject has no usable name: the file falls back to `<form-title>_<date>`, and to `form_<date>` if neither is usable.

`PDFGenerationService._generatePdfFromHtml` is untouched. It already renames the generated file to the exact name before handing it to the share sheet, which is what makes the name visible to the receiving app.

## Verification

`test/service/PdfFileNameTest.js` adds 6 cases: the normal shape, two patients not colliding on the same day, both fallbacks, accent and punctuation stripping, and non-Latin names.

On this branch, `test/service/{PdfFileName,*Share,*PDF}` runs **5 suites, 38 tests, all passing**.

Worth noting for reviewers: `_.snakeCase` preserves non-Latin scripts rather than dropping them, so a Devanagari name yields `रमेश_कुमार_referral_slip_<date>`. That is asserted in the test rather than assumed. Android filenames accept it; it has not been exercised on a physical device across every share target.

## Not included

Making the file name configurable per implementation, for example by honouring an optional `fileName` from the share rule. That would be the natural follow-up if organisations want a case ID or similar in the name; this change just makes the default useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF filenames now include the subject’s name, form title, and date when available.
  * Filenames are consistently formatted and remain usable with accented or non-Latin names.
  * Generic fallback names are provided when subject and form details are unavailable.

* **Bug Fixes**
  * Improved filename uniqueness when sharing PDFs for different subjects.

* **Tests**
  * Added coverage for filename formatting, fallbacks, sanitization, and multilingual names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->