### PR TITLE
#SCRUM-51 | Hide the "Any" chip on the registration address picker

### DIFF
--- a/packages/openchs-android/src/views/common/AddressLevels.js
+++ b/packages/openchs-android/src/views/common/AddressLevels.js
@@ -25,6 +25,7 @@ class AddressLevels extends AbstractComponent {
         mandatory: PropTypes.bool,
         addressLevelState: PropTypes.object,
         skipLabel: PropTypes.bool,
+        skipAnyChip: PropTypes.bool,
         minLevelTypeUUIDs: PropTypes.array,
         maxLevelTypeUUID: PropTypes.string,
         isOutsideCatchment: PropTypes.bool,
@@ -154,7 +155,9 @@ class AddressLevels extends AbstractComponent {
         let addressLevels = renderedLevels.map(([levelType, levels], idx) => {
             const isLeaf = idx === lastIdx;
             const isLowestInHierarchy = this.addressLevelService.isOnLowestLevel(levels, this.props.minLevelTypeUUIDs);
-            const showAny = !isLowestInHierarchy;
+            // Registration must end on a concrete lowest-level address, so a chip that only widens the
+            // list below reads as "this level is optional" there. Callers that need it opt out.
+            const showAny = !isLowestInHierarchy && !this.props.skipAnyChip;
             const anyActive = this.state.data.isAnyActive(levelType);
             const onHeaderChipPress = showAny ? () => this.onToggleAny(levelType) : undefined;
             const headerChipLabel = showAny ? anyLabel : undefined;

--- a/packages/openchs-android/src/views/individual/PersonRegisterView.js
+++ b/packages/openchs-android/src/views/individual/PersonRegisterView.js
@@ -152,6 +152,7 @@ class PersonRegisterView extends AbstractComponent {
                             multiSelect={false}
                             validationError={AbstractDataEntryState.getValidationError(this.state, Individual.validationKeys.LOWEST_ADDRESS_LEVEL)}
                             mandatory={true}
+                            skipAnyChip={true}
                             onLowestLevel={(lowestSelectedAddresses) =>
                                 this.dispatchAction(Actions.REGISTRATION_ENTER_ADDRESS_LEVEL, {value: _.head(lowestSelectedAddresses)})}
                             minLevelTypeUUIDs={this.state.minLevelTypeUUIDs}

--- a/packages/openchs-android/src/views/subject/SubjectRegisterView.js
+++ b/packages/openchs-android/src/views/subject/SubjectRegisterView.js
@@ -192,6 +192,7 @@ class SubjectRegisterView extends AbstractComponent {
                             multiSelect={false}
                             validationError={AbstractDataEntryState.getValidationError(this.state, Individual.validationKeys.LOWEST_ADDRESS_LEVEL)}
                             mandatory={true}
+                            skipAnyChip={true}
                             onLowestLevel={(lowestSelectedAddresses) => {
                                 this.dispatchAction(Actions.REGISTRATION_ENTER_ADDRESS_LEVEL, {value: _.head(lowestSelectedAddresses)})
                             }


### PR DESCRIPTION
Tanuh feedback item 127: the registration address picker shows an "Any" chip on District and Taluka but not on Village, which reads as inconsistent to field users.

The chip means "don't narrow by this level — show me everything underneath it", so the lowest level correctly has none. But registration is single-select and mandatory down to that lowest level, so a chip above it reads as "this level is optional", which it isn't. Tanuh chose to drop it from registration rather than add a meaningless one at the bottom — a chip on the lowest level could only do nothing or clear the answer.

### Changed

- `AddressLevels.js` — new `skipAnyChip` prop gating `showAny`, named to match the existing `skipLabel` opt-out on the same component
- `PersonRegisterView.js`, `SubjectRegisterView.js` — pass `skipAnyChip={true}`

Both registration views, so a non-person subject type added later doesn't get the chip back. `FamilyRegisterView` is untouched (legacy family-folder flow).

### Unchanged

Filters, search and `LocationHierarchyInput` keep the chip, where it genuinely helps — it lets a user see all children without committing to a parent first. For Tanuh that is *Place of referral* (District → Taluka Hospital) and *Biopsy hospital (referral)* (State → District Hospital).

### ⚠️ Not safe to merge upstream as-is

The gate is unconditional — there is no flavour check and no org check, and the client carries no flavour marker at runtime. Merging this into `newmodel` or `master`, or cherry-picking `144b1edf0`, removes the chip from the registration address picker for **every Avni org**, and nothing in the diff would warn them.

To take it upstream, gate it on an org-config flag first — `OrganisationConfigService.hideAnyChipOnRegistration()` reading `organisationConfig.settings`, in the same shape as the existing `saveDrafts` / `showSummaryButton` / `guideUserToRegisterButton` flags. Tanuh then sets one key in its bundle and every other org keeps the chip by default.

### Testing

Pure JS render change; no native code and no test covers `AddressLevels` rendering. Verification is on-device, tracked on SCRUM-52 — the part worth checking is that *Place of referral* and *Biopsy hospital (referral)* **still show** their chip, since those share the component and would prove the scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
