### PR TITLE
#2064 | Geotag ImageV2 captures when only approximate location is granted

### DIFF
--- a/packages/openchs-android/src/utility/DeviceLocation.js
+++ b/packages/openchs-android/src/utility/DeviceLocation.js
@@ -11,26 +11,33 @@ export default class DeviceLocation {
             return true;
         }
 
-        const hasPermission = await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION);
+        // Approximate (COARSE) location is enough to geotag a photo, so it counts as granted just like FINE -
+        // requesting FINE again here when the user already granted COARSE would re-prompt for a permission
+        // they already declined.
+        const [hasFine, hasCoarse] = await Promise.all([
+            PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION),
+            PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION)
+        ]);
 
-        if (hasPermission) return true;
+        if (hasFine || hasCoarse) return true;
 
         try {
-            const status = await Promise.race([
-                PermissionsAndroid.request(
-                    PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION
-                ),
+            const statuses = await Promise.race([
+                PermissionsAndroid.requestMultiple([
+                    PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+                    PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION
+                ]),
                 new Promise((_, reject) => setTimeout(() => reject(new Error('Permission request timeout')), 10000))
             ]);
 
-            if (status === PermissionsAndroid.RESULTS.GRANTED) return true;
+            const fineStatus = statuses[PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION];
+            const coarseStatus = statuses[PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION];
 
-            if (status === PermissionsAndroid.RESULTS.DENIED) {
-                General.logWarn("DeviceLocation", "Location permission denied by user");
-            } else if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
-                General.logWarn("DeviceLocation", "Location permission revoked by user");
+            if (fineStatus === PermissionsAndroid.RESULTS.GRANTED || coarseStatus === PermissionsAndroid.RESULTS.GRANTED) {
+                return true;
             }
 
+            General.logWarn("DeviceLocation", `Location permission denied by user (fine: ${fineStatus}, coarse: ${coarseStatus})`);
             return false;
         } catch (error) {
             General.logWarn("DeviceLocation", `Permission request failed: ${error.message}`);

--- a/packages/openchs-android/src/utility/DevicePermissions.js
+++ b/packages/openchs-android/src/utility/DevicePermissions.js
@@ -22,8 +22,12 @@ export default class DevicePermissions {
         return false;
     }
 
-    static hasDeviceLocation() {
-        return PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION);
+    static async hasDeviceLocation() {
+        const [fine, coarse] = await Promise.all([
+            PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION),
+            PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION)
+        ]);
+        return fine || coarse;
     }
 
     static showPermissionDeniedAlert({titleKey, messageKey}) {

--- a/packages/openchs-android/test/utility/DeviceLocationTest.js
+++ b/packages/openchs-android/test/utility/DeviceLocationTest.js
@@ -1,0 +1,71 @@
+import {assert} from "chai";
+import {Platform, PermissionsAndroid} from "react-native";
+
+jest.mock('react-native-geolocation-service', () => ({
+    getCurrentPosition: jest.fn()
+}));
+// IssueUploadUtil pulls in BackupRestoreRealmService's native-module chain (zip-archive, realm, ...),
+// none of which askLocationPermission touches - stub it out rather than mocking that whole chain.
+jest.mock('../../src/utility/IssueUploadUtil', () => ({
+    createUploadIssueInfoButton: jest.fn()
+}));
+
+import DeviceLocation from "../../src/utility/DeviceLocation";
+
+describe('DeviceLocation.askLocationPermission', () => {
+    let requestedPermissions;
+
+    beforeEach(() => {
+        Platform.OS = 'android';
+        Platform.Version = 33;
+        requestedPermissions = [];
+        PermissionsAndroid.check = () => Promise.resolve(false);
+        PermissionsAndroid.requestMultiple = (permissions) => {
+            requestedPermissions.push(permissions);
+            return Promise.resolve({});
+        };
+    });
+
+    it('returns true without requesting when fine location is already granted', async () => {
+        PermissionsAndroid.check = (permission) => Promise.resolve(permission === PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION);
+
+        assert.isTrue(await DeviceLocation.askLocationPermission());
+        assert.lengthOf(requestedPermissions, 0);
+    });
+
+    it('returns true without requesting when only coarse location is already granted', async () => {
+        PermissionsAndroid.check = (permission) => Promise.resolve(permission === PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION);
+
+        assert.isTrue(await DeviceLocation.askLocationPermission());
+        assert.lengthOf(requestedPermissions, 0);
+    });
+
+    it('requests both fine and coarse together when neither is granted', async () => {
+        PermissionsAndroid.requestMultiple = (permissions) => {
+            requestedPermissions.push(permissions);
+            return Promise.resolve({
+                [PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION]: PermissionsAndroid.RESULTS.DENIED,
+                [PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION]: PermissionsAndroid.RESULTS.GRANTED
+            });
+        };
+
+        assert.isTrue(await DeviceLocation.askLocationPermission());
+        assert.lengthOf(requestedPermissions, 1);
+        assert.includeMembers(requestedPermissions[0], [
+            PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+            PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION
+        ]);
+    });
+
+    it('returns false when the user denies both fine and coarse', async () => {
+        PermissionsAndroid.requestMultiple = (permissions) => {
+            requestedPermissions.push(permissions);
+            return Promise.resolve({
+                [PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION]: PermissionsAndroid.RESULTS.DENIED,
+                [PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION]: PermissionsAndroid.RESULTS.DENIED
+            });
+        };
+
+        assert.isFalse(await DeviceLocation.askLocationPermission());
+    });
+});

--- a/packages/openchs-android/test/utility/DevicePermissionsTest.js
+++ b/packages/openchs-android/test/utility/DevicePermissionsTest.js
@@ -62,3 +62,23 @@ describe('DevicePermissions', () => {
         assert.lengthOf(alertArgs, 0);
     });
 });
+
+describe('DevicePermissions.hasDeviceLocation', () => {
+    beforeEach(() => {
+        PermissionsAndroid.check = () => Promise.resolve(false);
+    });
+
+    it('is true when fine location is granted', async () => {
+        PermissionsAndroid.check = (permission) => Promise.resolve(permission === PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION);
+        assert.isTrue(await DevicePermissions.hasDeviceLocation());
+    });
+
+    it('is true when only approximate (coarse) location is granted', async () => {
+        PermissionsAndroid.check = (permission) => Promise.resolve(permission === PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION);
+        assert.isTrue(await DevicePermissions.hasDeviceLocation());
+    });
+
+    it('is false when neither fine nor coarse location is granted', async () => {
+        assert.isFalse(await DevicePermissions.hasDeviceLocation());
+    });
+});


### PR DESCRIPTION
## Summary
- `DevicePermissions.hasDeviceLocation()` and `DeviceLocation.askLocationPermission()` only checked `ACCESS_FINE_LOCATION`, so on Android 12+ a COARSE-only grant made `MediaV2FormElement.launchCamera` skip the GPS fix entirely and save the photo without a geotag.
- Both now accept either FINE or COARSE. `askLocationPermission()` also batches the FINE+COARSE request so it won't re-prompt for a permission the user already granted.

Fixes #2064.

## Test plan
- [x] `DevicePermissionsTest.js` — added cases for `hasDeviceLocation()` with FINE-only, COARSE-only, and neither granted
- [x] `DeviceLocationTest.js` (new) — covers `askLocationPermission()` not re-requesting when either is already granted, batching both when neither is granted, and returning false only when both are denied
- [x] Full `make test` run: no new failures introduced (pre-existing environment gaps in unrelated suites)